### PR TITLE
fix: fallback to empty array for users with no repos

### DIFF
--- a/packages/saber-theme-portfolio/src/saber-node.js
+++ b/packages/saber-theme-portfolio/src/saber-node.js
@@ -15,6 +15,22 @@ exports.beforePlugins = async function() {
       url: usePinnedRepos
         ? `https://gh-pinned-repos.now.sh/?username=${github}`
         : `https://api.github.com/search/repositories?q=user:${github}&sort:stars&per_page=6`
+    }).catch(error => {
+      if (usePinnedRepos) {
+        throw error
+      }
+
+      // No repos
+      if (
+        error.response &&
+        error.response.status === 422 &&
+        error.response.data &&
+        error.response.data.message === 'Validation Failed'
+      ) {
+        return { data: { items: [] } }
+      }
+
+      throw error
     })
   ])
 


### PR DESCRIPTION
GitHub throws HTTP error 422 when you search for repos from an user with no repos.

This approach detects it and return an empty array to properly be handled later.

You can test it going [here](https://api.github.com/search/repositories?q=user:DQ313&sort:stars&per_page=6).

```json
{
  "message": "Validation Failed",
  "errors": [
    {
      "message": "The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.",
      "resource": "Search",
      "field": "q",
      "code": "invalid"
    }
  ],
  "documentation_url": "https://developer.github.com/v3/search/"
}
```