### PR TITLE
Added a fixed height to skill descriptions

### DIFF
--- a/packages/saber-theme-portfolio/src/components/SkillCard.vue
+++ b/packages/saber-theme-portfolio/src/components/SkillCard.vue
@@ -45,5 +45,10 @@ export default {
 
 .skill-description {
   color: var(--text-color-lighter);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;  
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/packages/saber-theme-portfolio/src/components/SkillCard.vue
+++ b/packages/saber-theme-portfolio/src/components/SkillCard.vue
@@ -47,7 +47,7 @@ export default {
   color: var(--text-color-lighter);
   display: -webkit-box;
   -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;  
+  -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/packages/saber-theme-portfolio/src/components/SkillCard.vue
+++ b/packages/saber-theme-portfolio/src/components/SkillCard.vue
@@ -45,10 +45,11 @@ export default {
 
 .skill-description {
   color: var(--text-color-lighter);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  display: block;
   text-overflow: ellipsis;
+  word-wrap: break-word;
+  overflow: hidden;
+  max-height: 3.6em;
+  line-height: 1.8em;
 }
 </style>

--- a/packages/saber-theme-portfolio/src/components/SkillCard.vue
+++ b/packages/saber-theme-portfolio/src/components/SkillCard.vue
@@ -44,7 +44,7 @@ export default {
 }
 
 .skill-description {
-  color: var(--text-color-lighter);
+  color: var(--text-color-light);
   display: block;
   text-overflow: ellipsis;
   word-wrap: break-word;


### PR DESCRIPTION
Closes #162. 

Fixes skill card description to 2 lines.

Also changed skill card text colour to match the rest of the site.

Change is cross-browser compatible. 